### PR TITLE
fix: removed badge_type field from badge

### DIFF
--- a/amundsen_common/models/table.py
+++ b/amundsen_common/models/table.py
@@ -37,7 +37,6 @@ class TagSchema(AttrsSchema):
 class Badge:
     badge_name: str = attr.ib()
     category: str = attr.ib()
-    badge_type: str = attr.ib()
 
 
 class BadgeSchema(AttrsSchema):


### PR DESCRIPTION
### Summary of Changes

Removed badge_type from Badge as this configurable field is only relevant for FE.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
