### PR TITLE
fix: changed marshmallow-annotation version, temp solution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 attrs==19.1.0
 flake8==3.7.8
 Flask==1.1.1
-marshmallow==2.15.3
-marshmallow-annotations==2.4.0
+marshmallow==3.6.0
+git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bdef36555082df990ed9bef#egg=marshmallow-annotations
 mypy==0.761
 pytest>=4.6
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='amundsen-common',
-    version='0.5.7',
+    version='0.5.8',
     description='Common code library for Amundsen',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
         # long as they have a version of pyfoobar equal to or greater than 1.x
         # and less than 2.x installed.
         'flask>=1.0.2',
-        'marshmallow>=2.15.3,<3.0',
-        'marshmallow-annotations>=2.4.0,<3.0'
+        'marshmallow>=2.15.3,<=3.6',
+        'git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bdef36555082df990ed9bef#egg=marshmallow-annotations'
     ],
     python_requires=">=3.6",
     package_data={'amundsen_common': ['py.typed']},

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
         # and less than 2.x installed.
         'flask>=1.0.2',
         'marshmallow>=2.15.3,<=3.6',
-        'git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bdef36555082df990ed9bef#egg=marshmallow-annotations'
+        ('git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bd'
+         'ef36555082df990ed9bef#egg=marshmallow-annotations')
     ],
     python_requires=">=3.6",
     package_data={'amundsen_common': ['py.typed']},


### PR DESCRIPTION

### Summary of Changes

Using git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bdef36555082df990ed9bef#egg=marshmallow-annotations as marshmallow-annotations version while waiting for dep to be maintained and compatible with marshmallow >3.0.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
