### PR TITLE
chore: have dependabot only check for patches monthly (vs weekly)

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,4 +2,4 @@ version: 1
 update_configs:
   - package_manager: "python"
     directory: "/"
-    update_schedule: "weekly"
+    update_schedule: "monthly"


### PR DESCRIPTION
We're not keeping up with these at the moment, so they're quite noisy. I think we would be OK switching to a slower cadence and taking them a bit more seriously.

If this LGTY I'll apply this to other repos as well.

cc @feng-tao @allisonsuarez 

Signed-off-by: Dorian Johnson <2020@dorianj.net>

<!---
Provide a general summary of your changes in the Title above
Include one of these prefixes:
  fix – Fixes an unexpected problem or unintended behavior
  feat – Adds a new feature
  docs – A documentation improvement task
  build – A task related to our build system
  ci – A task related to our ci system
  perf – A performance improvement
  refactor – A code refactor PR
  style – A task about styling
  test – A PR that improve test coverage
  chore – A regular maintenance chore or task
  other – Any other kind of PR
-->

### Summary of Changes

_Include a summary of changes then remove this line_

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes.
