### PR TITLE
fix: standardize requirements and fixes for marshmallow3+

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 # review when someone opens a pull request.
 *       @amundsen-io/amundsen-committers
 
-*.py    @feng-tao @jinhyukchang @allisonsuarez @dikshathakur3119 @verdan @bolkedebruin @mgorsk1
+*.py    @feng-tao @jinhyukchang @allisonsuarez @verdan @bolkedebruin @mgorsk1

--- a/.github/tests.yml
+++ b/.github/tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: 'Install dependencies'
         run: pip install -r requirements.txt
       - name: 'Install project'
-        run: python setup.py install
+        run: pip install .
       - name: 'Run tests'
         run: make test_unit
   codecov:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
- clean:
+clean:
 	find . -name \*.pyc -delete
 	find . -name __pycache__ -delete
 	rm -rf dist/
 
- test_unit:
+test_unit:
 	python -m pytest tests
 	python3 -bb -m pytest tests
 
@@ -16,4 +16,4 @@ mypy:
 	mypy .
 
 
- test: test_unit lint mypy
+test: test_unit lint mypy

--- a/amundsen_common/models/user.py
+++ b/amundsen_common/models/user.py
@@ -57,7 +57,7 @@ class UserSchema(AttrsSchema):
         return False
 
     @pre_load
-    def preprocess_data(self, data: Dict[str, Any]) -> Dict[str, Any]:
+    def preprocess_data(self, data: Dict[str, Any], **kwargs) -> Dict[str, Any]:
         if self._str_no_value(data.get('user_id')):
             data['user_id'] = data.get('email')
 
@@ -81,7 +81,7 @@ class UserSchema(AttrsSchema):
         return data
 
     @validates_schema
-    def validate_user(self, data: Dict[str, Any]) -> None:
+    def validate_user(self, data: Dict[str, Any], **kwargs) -> None:
         if self._str_no_value(data.get('display_name')):
             raise ValidationError('"display_name", "full_name", or "email" must be provided')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-attrs==19.1.0
 flake8==3.7.8
-Flask==1.1.1
-marshmallow==3.6.0
-git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bdef36555082df990ed9bef#egg=marshmallow-annotations
 mypy==0.761
 pytest>=4.6
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = '0.8.1'
+__version__ = '0.8.2'
 
 setup(
     name='amundsen-common',
@@ -15,10 +15,6 @@ setup(
     maintainer='Amundsen TSC',
     maintainer_email='amundsen-tsc@lists.lfai.foundation',
     packages=find_packages(exclude=['tests*']),
-    dependency_links=[
-        ('git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bd'
-         'ef36555082df990ed9bef#egg=marshmallow-annotations')
-    ],
     install_requires=[
         # Packages in here should rarely be pinned. This is because these
         # packages (at the specified version) are required for project
@@ -35,9 +31,10 @@ setup(
         # This will allow for any consuming projects to use this library as
         # long as they have a version of pyfoobar equal to or greater than 1.x
         # and less than 2.x installed.
-        'flask>=1.0.2',
+        'Flask>=1.0.2',
+        'attrs>=19.0.0',
         'marshmallow>=3.0,<=3.6',
-        'marshmallow-annotations'
+        'marshmallow-annotations @ git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bdef36555082df990ed9bef#egg=marshmallow-annotations-2.4.0.post1'
     ],
     python_requires=">=3.6",
     package_data={'amundsen_common': ['py.typed']},


### PR DESCRIPTION
Signed-off-by: Dmitriy Kunitskiy <dkunitskiy@lyft.com>

### Summary of Changes

- adds a `**kwargs` arg to decorated methods per [marshmallow3 docs](https://marshmallow.readthedocs.io/en/stable/upgrading.html#decorated-methods-and-handle-error-receive-many-and-partial). This was blocking downstream adoption. 
- standardize requirements handling:
  - in packages, setup.py's `install_requires` are installed by pip and requirements.txt are for the repo's own functionality. Generally requirements.txt should not repeat the packages in setup.py. Have changed to follow this convention. 
  - As of pip 18, `dependency_links` are NOT followed and the correct way to specify direct url dependencies is by putting them in install_requires using the `repo @ git+url` syntax. [Pip19 even removed](https://pip.pypa.io/en/stable/news/#id443) the `--follow-dependency-links` option.
  - Moment of weirdness: the way we install this package for testing with `python setup.py install` does not use pip, it uses setuptools+easy_install which is old school. Turns out that setuptools only knows how to use dependency_links and does not know the syntax above. So I believe the answer is to include marshmallow-annotations in BOTH dependency_links AND install_requires. The former will be for `python3 install setup.py` and the latter for consumers who install this package via pip. The other option is to change [this line](https://github.com/amundsen-io/amundsencommon/blob/master/.github/tests.yml#L16) to run `pip install .`. But since `python3 install setup.py` is so ubiquitously encouraged in Amundsen-land I wanted this to continue working. 


### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
