### PR TITLE
fix: downgrade marshmallow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ setup(
         # and less than 2.x installed.
         'Flask>=1.0.2',
         'attrs>=19.0.0',
-        'marshmallow>=3.0,<=3.6',
-        'marshmallow-annotations @ git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bdef36555082df990ed9bef#egg=marshmallow-annotations'  # noqa
+        'marshmallow<3.0',
+        'marshmallow-annotations==2.4.0'
     ],
     python_requires=">=3.6",
     package_data={'amundsen_common': ['py.typed']},

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ setup(
         # and less than 2.x installed.
         'Flask>=1.0.2',
         'attrs>=19.0.0',
-        'marshmallow<3.0',
-        'marshmallow-annotations==2.4.0'
+        'marshmallow>=2.15.3,<3.0',
+        'marshmallow-annotations>=2.4.0,<3.0'
     ],
     python_requires=">=3.6",
     package_data={'amundsen_common': ['py.typed']},


### PR DESCRIPTION
### Summary of Changes

The current way of pinning dependencies blocks us from publishing package to pypi & prevents installation of amundsen in the environments where direct to access to gihtub is prohibited (eg. behind corporate proxy).

```
Uploading amundsen_common-0.8.2-py3-none-any.whl

  0%|          | 0.00/23.9k [00:00<?, ?B/s]
100%|██████████| 23.9k/23.9k [00:00<00:00, 129kB/s]
NOTE: Try --verbose to see response content.
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
Invalid value for requires_dist. Error: Can't have direct dependency: 'marshmallow-annotations @ git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bdef36555082df990ed9bef#egg=marshmallow-annotations'
```

marshmallow-annotations according to it's maintainer is pretty much abandoned in terms of support, it has not been released for months and is not compatible with marshmallow 3+.

### CheckList

Make sure you have checked **all** steps below to ensure a timely review.

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
