### PR TITLE
fix: switch to forked marshmallow3-annotations package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ venv3/
 .coverage
 .mypy_cache
 .pytest_cache
-
+.python-version

--- a/amundsen_common/models/dashboard.py
+++ b/amundsen_common/models/dashboard.py
@@ -4,7 +4,7 @@
 from typing import List, Optional
 
 import attr
-from marshmallow_annotations.ext.attrs import AttrsSchema
+from marshmallow3_annotations.ext.attrs import AttrsSchema
 
 
 @attr.s(auto_attribs=True, kw_only=True)

--- a/amundsen_common/models/lineage.py
+++ b/amundsen_common/models/lineage.py
@@ -6,7 +6,7 @@ from typing import Optional, List
 from amundsen_common.models.table import Badge
 
 import attr
-from marshmallow_annotations.ext.attrs import AttrsSchema
+from marshmallow3_annotations.ext.attrs import AttrsSchema
 
 
 @attr.s(auto_attribs=True, kw_only=True)

--- a/amundsen_common/models/popular_table.py
+++ b/amundsen_common/models/popular_table.py
@@ -4,7 +4,7 @@
 from typing import Optional
 
 import attr
-from marshmallow_annotations.ext.attrs import AttrsSchema
+from marshmallow3_annotations.ext.attrs import AttrsSchema
 
 
 @attr.s(auto_attribs=True, kw_only=True)

--- a/amundsen_common/models/table.py
+++ b/amundsen_common/models/table.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 import attr
 
 from amundsen_common.models.user import User
-from marshmallow_annotations.ext.attrs import AttrsSchema
+from marshmallow3_annotations.ext.attrs import AttrsSchema
 
 
 @attr.s(auto_attribs=True, kw_only=True)

--- a/amundsen_common/models/user.py
+++ b/amundsen_common/models/user.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Dict
 
 import attr
 from marshmallow import ValidationError, validates_schema, pre_load
-from marshmallow_annotations.ext.attrs import AttrsSchema
+from marshmallow3_annotations.ext.attrs import AttrsSchema
 
 """
 TODO: Explore all internationalization use cases and

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ commit_author = github-actions <github-actions@github.com>
 [mypy-marshmallow.*]
 ignore_missing_imports = true
 
-[mypy-marshmallow_annotations.*]
+[mypy-marshmallow3_annotations.*]
 ignore_missing_imports = true
 
 [mypy-setuptools.*]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import find_packages, setup
 
-__version__ = '0.8.2'
+__version__ = '0.9.0'
 
 setup(
     name='amundsen-common',
@@ -15,14 +15,6 @@ setup(
     maintainer='Amundsen TSC',
     maintainer_email='amundsen-tsc@lists.lfai.foundation',
     packages=find_packages(exclude=['tests*']),
-    # pip ignores dependency_links and only installs the `marshmallow-annotations @ ...` requirement
-    # specified in install_requires. Unfortunately easy_install which is invoked by `python setup.py install`
-    # does the opposite. For this reason we include this private fork in both sections so both easy_install and
-    # pip pick this up.
-    dependency_links=[
-        ('git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bd'
-         'ef36555082df990ed9bef#egg=marshmallow-annotations')
-    ],
     install_requires=[
         # Packages in here should rarely be pinned. This is because these
         # packages (at the specified version) are required for project
@@ -41,8 +33,8 @@ setup(
         # and less than 2.x installed.
         'Flask>=1.0.2',
         'attrs>=19.0.0',
-        'marshmallow>=3.0,<=3.6',
-        'marshmallow-annotations @ git+https://www.github.com/hilearn/marshmallow-annotations.git@a7a2dc96932430369bdef36555082df990ed9bef#egg=marshmallow-annotations'  # noqa
+        'marshmallow>=3.0',
+        'marshmallow3-annotations>=1.0.0'
     ],
     python_requires=">=3.6",
     package_data={'amundsen_common': ['py.typed']},


### PR DESCRIPTION
We've been in a broken state due to marshmallow-annotations, and this is an attempt at a longer term fix. 

I have created and uploaded to PyPI my own fork of `marshmallow-annotations` (cleverly titled `marshmallow3-annotations`). The main changes with the upstream are in https://github.com/dkunitsk/marshmallow3-annotations/pull/1. 

This PR rolls us over onto that fork. Once merged, I will go through Amundsen's other repos and migrate them also (to new `amundsencommon`, and by extension to `marshmallow3-annotations`).


Signed-off-by: Dmitriy Kunitskiy <dkunitskiy@lyft.com>

- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes.
